### PR TITLE
fixed? a prompt file frame number miscalculation

### DIFF
--- a/Export_to_stable_diffusion/ESD_export_functions.jsx
+++ b/Export_to_stable_diffusion/ESD_export_functions.jsx
@@ -267,7 +267,7 @@ function exportImageSequence(singleFrame) {
             if (singleFrame) {
                 var fileFrameNumber = i + startFrameNumber - workStartFrame - 1;
             } else {
-                var fileFrameNumber = i + startFrameNumber - 1;
+                var fileFrameNumber = i + startFrameNumber; //need to figure out the conditions under which this needs to be startFrameNumber - 1
             }
             var fileAndPath = fileWithPath(f.toString(),comp.name + "_" + ("00000" + fileFrameNumber).slice(-5) + ".png"); //will change this to use padStart once I can get that working.
 


### PR DESCRIPTION
Rolled back a change that caused the prompt file to reference frame numbers of 0000-1. Will need to do more testing to determine what conditions require changes to frame number calculations.